### PR TITLE
Exposed load and dump functions

### DIFF
--- a/python-flask/flask_jsonplus/__init__.py
+++ b/python-flask/flask_jsonplus/__init__.py
@@ -40,5 +40,11 @@ class FlaskJSONPlus(object):
     def loads(*pa, **kw):
         return jsonplus.loads(*pa, **kw)
 
+    def dump(*pa, **kw):
+        return jsonplus.dump(*pa, **kw)
+
+    def load(*pa, **kw):
+        return jsonplus.load(*pa, **kw)
+
     def pretty(obj, **kw):
         return jsonplus.pretty(obj, **kw)

--- a/python/jsonplus/__init__.py
+++ b/python/jsonplus/__init__.py
@@ -22,9 +22,9 @@ except ImportError:
     # defer failing to actual (de-)serialization
     pass
 
-__all__ = ["loads", "dumps", "pretty",
-           "json_loads", "json_dumps", "json_prettydump",
-           "encoder", "decoder"]
+__all__ = ["loads", "dumps", "load", "dump", "pretty",
+           "json_loads", "json_dumps", "json_load", "json_dump",
+           "json_prettydump", "encoder", "decoder"]
 
 
 # Should we aim for the *exact* reproduction of Python types,
@@ -304,6 +304,16 @@ def loads(*pa, **kw):
     return json.loads(*pa, **kw)
 
 
+def dump(*pa, **kw):
+    _encoder_default_args(kw)
+    return json.dump(*pa, **kw)
+
+
+def load(*pa, **kw):
+    _decoder_default_args(kw)
+    return json.load(*pa, **kw)
+
+
 def pretty(x, sort_keys=True, indent=4*' ', separators=(',', ': '), **kw):
     kw.setdefault('sort_keys', sort_keys)
     kw.setdefault('indent', indent)
@@ -314,6 +324,8 @@ def pretty(x, sort_keys=True, indent=4*' ', separators=(',', ': '), **kw):
 
 json_dumps = dumps
 json_loads = loads
+json_dump = dump
+json_load = load
 json_prettydump = pretty
 
 


### PR DESCRIPTION
In order to be a "drop in replacement" to the standard json and simplejson libraries, Jsonplus should expose both `load` and `dump` methods.
Those functions are still used when dealing with large objects and files or data streams as it is more efficient, than serializing to string first, than pushing that string into the stream or file.

I'm not sure, how you do versioning, so I did not touch the version number. But I think it should be incremented to 0.8.1 or something.